### PR TITLE
Feat/neo-rpc: Retrive all methods in the module into a single list with getNodesByX

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ With neo-tools in place, one has easy lookup of various operations and functions
 
 ## Project Version and Status
 
-Version: 0.55.0
+Version: 0.56.0
 
 Status: Writing alpha code (see section Features below), documenting goals, and defining standards.
 
@@ -100,6 +100,7 @@ See src/nodejs/ for the following:
   * Automatically select nodes
   * Get nodes by configurable sort factor
   * GetNodesByX
+    * Be careful, this can produce a lot of node traffic. It first pings each node in the list generated or provided to make sure they are up and within operating parameters and then calls the respective method requested. See [neo-rpc](#neo-rpc) for examples.
 
 
 * Configuration via nodejs/src/config.js
@@ -344,7 +345,7 @@ node account/cli/list.js -n test
 ```
 
 
-#### Neo-rpc
+#### neo-rpc
 Implementation of various Neo: v2.9.0 RPC utilities, some running against neon-js.
 See: [Neo: v2.9.0](http://docs.neo.org/en-us/node/cli/2.9.0/api.html) for /Neo:v2.9.0/
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo-tools",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "Composable command line tools and reference implementations for Neo Smart Economy function primitives",
   "repository": {
     "type": "git",

--- a/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
@@ -33,10 +33,10 @@ program
   .option('-N, --Net [Net]', 'Select network [net]: i.e., TestNet or MainNet', 'TestNet')
   .option('-m, --method [method]', 'Get nodes by the given criteria, default is ping', 'ping')
   .option('-o, --order [order]', 'Order by \'asc\' (ascending <- default) or \'dsc\' (descending)', 'asc')
-  .option('-g, --getNodes', 'Get nodes from Neoscan ../v1/get_all_nodes REST API ')
+  .option('-g, --getNodes', 'Get nodes from Neoscan ../v1/get_all_nodes REST API. If not, will use config files if -n --node options aren\'t used. ')
 
   .on('--help', function(){
-    print('Note: -m --method options are: "ping", "tallest", "connection", "version", "rawmempool"')
+    print('Note: -m --method options are: "all", "ping", "tallest", "connection", "version", "rawmempool"')
   })
   .parse(process.argv)
 
@@ -62,7 +62,6 @@ else if (program.getNodes) {
 }
 
 getNodesBy[program.method.toLowerCase()](options).then(rankedNodes => {
-
   if (defly) dbg.logDeep(__filename + ': getNodesByPing().rankedNodes: ', rankedNodes)
   nodes = rankedNodes
   dbg.logDeep(' ', nodes)

--- a/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
@@ -34,6 +34,7 @@ program
   .option('-m, --method [method]', 'Get nodes by the given criteria, default is ping', 'ping')
   .option('-o, --order [order]', 'Order by \'asc\' (ascending <- default) or \'dsc\' (descending)', 'asc')
   .option('-g, --getNodes', 'Get nodes from Neoscan ../v1/get_all_nodes REST API. If not, will use config files if -n --node options aren\'t used. ')
+  .option('-c, --conf', 'Disable \'press any key to continue\' confirmation prompt')
 
   .on('--help', function(){
     print('Note: -m --method options are: "all", "ping", "tallest", "connection", "version", "rawmempool"')
@@ -61,11 +62,27 @@ else if (program.getNodes) {
    })
 }
 
-getNodesBy[program.method.toLowerCase()](options).then(rankedNodes => {
-  if (defly) dbg.logDeep(__filename + ': getNodesByPing().rankedNodes: ', rankedNodes)
-  nodes = rankedNodes
-  dbg.logDeep(' ', nodes)
-})
-.catch (error => {
-  print(__filename + ': ' + error.message)
-})
+function command() {
+  getNodesBy[program.method.toLowerCase()](options).then(rankedNodes => {
+    if (defly) dbg.logDeep(__filename + ': getNodesByPing().rankedNodes: ', rankedNodes)
+    nodes = rankedNodes
+    dbg.logDeep(' ', nodes)
+    process.exit()
+  })
+  .catch (error => {
+    print(__filename + ': ' + error.message)
+    process.exit()
+  })
+}
+
+if (program.conf) {
+  command()
+} else {
+  print('Warning: this can produce a lot of node traffic. It first pings each node in the list generated or provided to make sure they are up and within operating parameters and then calls the respective method requested.')
+  print('This can be disabled with -c or --conf.')
+  print('Press any key to continue...')
+
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+  process.stdin.on('data', command);
+}

--- a/src/nodejs/neo-rpc/v2.9.0/client/cli/query.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/cli/query.js
@@ -38,11 +38,12 @@ program
   .option('-T, --Txs', 'Only return an array of transactions for the block')
   .option('-H, --Human', 'I am human so make outputs easy for human')
   .option('-N, --Net [Net]', 'Select network [net]: i.e., TestNet or MainNet', 'TestNet')
-  .option('-m, --method [method]', 'Call node with this RPC method, default \'getBlockCount\'', 'getblockcount')
+  .option('-m, --method [method]', 'Call node with this RPC method, default \'getblockcount\'', 'getblockcount')
   .option('-p, --params [params]', 'Call RPC method with these params, default is blank', '')
   .on('--help', function(){
-    print("Note: Currently, arguments that modify the results of an RPC call are NOT IMPLEMENTED.")
-    print("      It Is highly recommended to use neo-rpc/client/cli/getNodesByX to find a node to use and then use this programs --node or -n option")
+    print('Note: Currently, arguments that modify the results of an RPC call are NOT IMPLEMENTED.')
+    print('      It Is highly recommended to use neo-rpc/client/cli/getNodesByX to find a node to use and then use this programs --node or -n option')
+    print('\nFor API /NEO:2.9.0/ See http://docs.neo.org/en-us/node/cli/2.9.0/api.html for a list of method names.')
   })
   .parse(process.argv)
 

--- a/src/nodejs/neo-rpc/v2.9.0/client/module/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/module/getNodesBy.js
@@ -357,7 +357,7 @@ exports.rawmempool = (options) => {
 // { 'nodeurl': { 'url': url, 'height': height, 'version': version, 'connections': connectionsCount, 'rawmempool': rawmempoolLength}}
 
 exports.all = (options) => {
-  let list = {}, i = 0, j = 0, objCopy, results = {}
+  let list = {}, objCopy, results = {}
   let getTallest = this.tallest
   getTallest.keyName = 'height'
   let getConnections = this.connection
@@ -370,23 +370,23 @@ exports.all = (options) => {
   let operations = [getTallest, getConnections, getVersion, getRawMemPool]
 
   return new Promise((resolve, reject) => {
-    operations.forEach(op => {
+    operations.forEach((op, outerIndex) => {
       op(options).then(rankedNodes => {
         list[op.keyName] = rankedNodes
 
-        if (i++ === operations.length-1) {
+        if (outerIndex === operations.length-1) {
           operations.forEach(op => {
             print('retrieving op: ' + op.keyName)
 
             list[op.keyName].forEach(node => {
-              operations.forEach(op2 => {
+              operations.forEach((op2, innerIndex) => {
                 list[op2.keyName].forEach(node2 => {
                   if (node.url === node2.url) {
                     objCopy = Object.assign(node, node2)
                     results[node.url] = objCopy
                   }
                 })
-                if (j++ === operations.length-1) {
+                if (innerIndex === operations.length-1) {
                   resolve(results)
                 }
               })

--- a/src/nodejs/neo-rpc/v2.9.0/client/module/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/module/getNodesBy.js
@@ -329,7 +329,7 @@ exports.rawmempool = (options) => {
             })
             .catch(error => {
               i++
-              print(__filename + ': getNodesBy.version().error: ' + error)
+              print(__filename + ': getNodesBy.rawmempool().error: ' + error)
               if (options.order === 'dsc') rankedList = rankedList.reverse()
               resolve(rankedList)
             })
@@ -339,6 +339,61 @@ exports.rawmempool = (options) => {
     })
     .catch (error => {
       print(__filename + ': getNodesBy.rawmempool()/getNodesBy.ping().error: ' + error)
+    })
+  })
+}
+
+
+// Return an object list of nodes with all stats this module can provide
+// ARGS:
+//  options = {
+//    net: 'TestNet',                                 // default network
+//    nodes: [{ 'url': 'https://host.domain:port' }], // defaults to empty
+//    order: 'asc'                                    // asc = lowest value first, dsc = highest first
+//  }
+// TODO: add caching with configurable time limit for results
+// This will ALWAYS ping first with getNodesBy.ping()
+// Return Value Format:
+// { 'nodeurl': { 'url': url, 'height': height, 'version': version, 'connections': connectionsCount, 'rawmempool': rawmempoolLength}}
+
+exports.all = (options) => {
+  let list = {}, i = 0, j = 0, objCopy, results = {}
+  let getTallest = this.tallest
+  getTallest.keyName = 'height'
+  let getConnections = this.connection
+  getConnections.keyName = 'connections'
+  let getVersion = this.version
+  getVersion.keyName = 'version'
+  let getRawMemPool = this.rawmempool
+  getRawMemPool.keyName = 'rawmempool'
+
+  let operations = [getTallest, getConnections, getVersion, getRawMemPool]
+
+  return new Promise((resolve, reject) => {
+    operations.forEach(op => {
+      op(options).then(rankedNodes => {
+        list[op.keyName] = rankedNodes
+
+        if (i++ === operations.length-1) {
+          operations.forEach(op => {
+            print('retrieving op: ' + op.keyName)
+
+            list[op.keyName].forEach(node => {
+              operations.forEach(op2 => {
+                list[op2.keyName].forEach(node2 => {
+                  if (node.url === node2.url) {
+                    objCopy = Object.assign(node, node2)
+                    results[node.url] = objCopy
+                  }
+                })
+                if (j++ === operations.length-1) {
+                  resolve(results)
+                }
+              })
+            })
+          })
+        }
+      })
     })
   })
 }

--- a/src/nodejs/neo-rpc/v2.9.0/client/module/query.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/module/query.js
@@ -9,7 +9,6 @@ require('module-alias/register')
 
 const axios   = require('axios')
 const _       = require('underscore')
-const neon    = require('@cityofzion/neon-js')
 
 const netUtil = require('nodejs_util/network')
 const dbg     = require('nodejs_util/debug')

--- a/src/nodejs/neo-rpc/v2.9.0/client/module/query.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/module/query.js
@@ -3,6 +3,7 @@
 // This is called by native/cli/rpc/neo-rpc/v2.9.0/cli/query.js CLI wrapper
 
 // Invoke an RPC method from CLI
+// See http://docs.neo.org/en-us/node/cli/2.9.0/api.html for a list of method names.
 
 
 require('module-alias/register')

--- a/src/nodejs/util/debug.js
+++ b/src/nodejs/util/debug.js
@@ -1,3 +1,9 @@
+// debug.js
+// This provides basic debugging capability
+
+// TODO add function key name with value function name to module exports
+// to help with debugging by function.
+
 require('module-alias/register')
 
 const util    = require('util')


### PR DESCRIPTION
- getNodesBy.all()
    - This can pull version, height, mempool, and connections into a single list sortable by node URL or any other value.

- Update notes for query.js to provide a reference link to API RPC method calls.

