### PR TITLE
Chore/neo rpc:  add CLI option to toggle ping first behavor of getNodesBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With neo-tools in place, one has easy lookup of various operations and functions
 
 ## Project Version and Status
 
-Version: 0.58.0
+Version: 0.59.0
 
 Status: Writing alpha code (see section Features below), documenting goals, and defining standards.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo-tools",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "Composable command line tools and reference implementations for Neo Smart Economy function primitives",
   "repository": {
     "type": "git",

--- a/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
@@ -25,7 +25,7 @@ function print(msg) {
 }
 
 program
-  .version('0.2.0')
+  .version('0.3.0')
   .usage('')
   .option('-d, --debug', 'Debug')
   .option('-n, --node [node]', 'Set RPC node to use (be sure to preface with https://), if not provided will try to use node with tallest block')

--- a/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/cli/getNodesBy.js
@@ -34,9 +34,11 @@ program
   .option('-o, --order [order]', 'Order by \'asc\' (ascending <- default) or \'dsc\' (descending)', 'asc')
   .option('-g, --getNodes', 'Get nodes from Neoscan ../v1/get_all_nodes REST API. If not, will use config files if -n --node options aren\'t used. ')
   .option('-c, --conf', 'Disable \'press any key to continue\' confirmation prompt')
+  .option('-p, --ping [ping]', 'Enable or disable ping first behavior (default 1 or true).', 1 )
 
   .on('--help', function(){
     print('Note: -m --method options are: "all", "ping", "tallest", "connection", "version", "rawmempool"')
+    print('-m "all" will ALWAYS ping first (for now).')
   })
   .parse(process.argv)
 
@@ -49,7 +51,8 @@ if (program.debug) {
 
 let options = {
   net: netUtil.resolveNetworkId(program.Net),
-  order: program.order
+  order: program.order,
+  ping: program.ping
 }
 
 // provided node argument on command line
@@ -76,6 +79,7 @@ function command() {
   if (ran) return
   else ran = true
 
+  print('Ping First: ' + options.ping)
   print('Using network: ' + options.net)
   print('Using method: ' + program.method)
   print('Node Count: ' + options.nodes.length)

--- a/src/nodejs/neo-rpc/v2.9.0/client/module/getNodesBy.js
+++ b/src/nodejs/neo-rpc/v2.9.0/client/module/getNodesBy.js
@@ -2,6 +2,11 @@
 
 // Module for helping get Neo Smart Economy RPC node servers
 
+// TODO move per instance callback functions out of function scope to make accessible to reuse
+// TODO review ssl issue
+// TODO look at dynamic selection defaults
+// TODO Look at ping toggle for "all" method
+
 require('module-alias/register')
 
 const _       = require('underscore')
@@ -77,7 +82,7 @@ exports.getRpcNodes = (options) => {
 //  options = {
 //    net: 'TestNet',                                 // default network
 //    nodes: [{ 'url': 'https://host.domain:port' }], // defaults to empty
-//    order: 'asc'                                    // asc = lowest value first, dsc = highest first
+//    order: 'asc',                                   // asc = lowest value first, dsc = highest first
 //  }
 // TODO: add caching with configurable time limit for results
 
@@ -146,7 +151,8 @@ exports.ping = (options) => {
 //  options = {
 //    net: 'TestNet',                                 // default network
 //    nodes: [{ 'url': 'https://host.domain:port' }], // defaults to empty
-//    order: 'dsc'                                    // asc = lowest value first, dsc = highest first
+//    order: 'dsc',                                   // asc = lowest value first, dsc = highest first
+//    ping: 1                                         // ping first, default true
 //  }
 // TODO: add caching with configurable time limit for results
 // This will ALWAYS ping first with getNodesBy.ping()
@@ -157,7 +163,18 @@ exports.tallest = (options) => {
   pingOptions.order = 'asc'
 
   return new Promise((resolve, reject) => {
-    this.ping(pingOptions).then(nodes => {
+    if (parseInt(options.ping)) {
+      this.ping(pingOptions).then(nodes => {
+        tallestCallback(nodes)
+      })
+      .catch (error => {
+        print(__filename + ': getNodesBy.tallest()/getNodesBy.ping().error: ' + error)
+      })
+    } else {
+      tallestCallback(options.nodes)
+    }
+
+    function tallestCallback(nodes) {
       if (_.isArray(nodes)) {
         nodes.forEach((n) => {
           if (n.url) {
@@ -177,7 +194,7 @@ exports.tallest = (options) => {
             })
             .catch(error => {
               i++
-              print(__filename + ': getNodesBy.tallest().error: ' + error)
+              print(__filename + ': ' + n.url + '.getNodesBy.tallest().error: ' + error)
 
               if (i === nodes.length) {
                 rankedList = _.sortBy(rankedList, 'height')
@@ -188,10 +205,7 @@ exports.tallest = (options) => {
           }
         })
       }
-    })
-    .catch (error => {
-      print(__filename + ': getNodesBy.tallest()/getNodesBy.ping().error: ' + error)
-    })
+    }
   })
 }
 
@@ -201,7 +215,8 @@ exports.tallest = (options) => {
 //  options = {
 //    net: 'TestNet',                                 // default network
 //    nodes: [{ 'url': 'https://host.domain:port' }], // defaults to empty
-//    order: 'asc'                                    // asc = lowest value first, dsc = highest first
+//    order: 'asc',                                   // asc = lowest value first, dsc = highest first
+//    ping: 1                                         // ping first, default true
 //  }
 // TODO: add caching with configurable time limit for results
 // This will ALWAYS ping first with getNodesBy.ping()
@@ -212,7 +227,19 @@ exports.connection = (options) => {
   pingOptions.order = 'asc'
 
   return new Promise((resolve, reject) => {
-    this.ping(pingOptions).then(nodes => {
+    if (parseInt(options.ping)) {
+      this.ping(pingOptions).then(nodes => {
+        connectionCallback(nodes)
+      })
+      .catch (error => {
+        print(__filename + ': getNodesBy.connections()/getNodesBy.ping().error: ' + error)
+      })
+    }
+    else {
+        connectionCallback(options.nodes)
+    }
+
+    function connectionCallback(nodes) {
       if (_.isArray(nodes)) {
         nodes.forEach((n) => {
           if (n.url) {
@@ -232,7 +259,7 @@ exports.connection = (options) => {
             })
             .catch(error => {
               i++
-              print(__filename + ': getNodesBy.connections().error: ' + error)
+              print(__filename + ': ' + n.url + '.getNodesBy.connections().error: ' + error)
 
               if (i === nodes.length) {
                 rankedList = _.sortBy(rankedList, 'connections')
@@ -243,10 +270,7 @@ exports.connection = (options) => {
           }
         })
       }
-    })
-    .catch (error => {
-      print(__filename + ': getNodesBy.connections()/getNodesBy.ping().error: ' + error)
-    })
+    }
   })
 }
 
@@ -256,7 +280,8 @@ exports.connection = (options) => {
 //  options = {
 //    net: 'TestNet',                                 // default network
 //    nodes: [{ 'url': 'https://host.domain:port' }], // defaults to empty
-//    order: 'dsc'                                    // asc = lowest value first, dsc = highest first
+//    order: 'dsc',                                   // asc = lowest value first, dsc = highest first
+//    ping: 1                                         // ping first, default true
 //  }
 // TODO: add caching with configurable time limit for results
 // This will ALWAYS ping first with getNodesBy.ping()
@@ -267,7 +292,19 @@ exports.version = (options) => {
   pingOptions.order = 'asc'
 
   return new Promise((resolve, reject) => {
-    this.ping(pingOptions).then(nodes => {
+    if (parseInt(options.ping)) {
+      this.ping(pingOptions).then(nodes => {
+        versionCallback(nodes)
+      })
+      .catch (error => {
+        print(__filename + ': getNodesBy.version()/getNodesBy.ping().error: ' + error)
+      })
+    }
+    else {
+      versionCallback(options.nodes)
+    }
+
+    function versionCallback(nodes) {
       if (_.isArray(nodes)) {
         nodes.forEach((n) => {
           if (n.url) {
@@ -287,7 +324,7 @@ exports.version = (options) => {
             })
             .catch(error => {
               i++
-              print(__filename + ': getNodesBy.version().error: ' + error)
+              print(__filename + ': ' + n.url + '.getNodesBy.version().error: ' + error)
 
               if (i === nodes.length) {
                 rankedList = _.sortBy(rankedList, 'version')
@@ -298,10 +335,7 @@ exports.version = (options) => {
           }
         })
       }
-    })
-    .catch (error => {
-      print(__filename + ': getNodesBy.version()/getNodesBy.ping().error: ' + error)
-    })
+    }
   })
 }
 
@@ -311,7 +345,8 @@ exports.version = (options) => {
 //  options = {
 //    net: 'TestNet',                                 // default network
 //    nodes: [{ 'url': 'https://host.domain:port' }], // defaults to empty
-//    order: 'asc'                                    // asc = lowest value first, dsc = highest first
+//    order: 'asc',                                   // asc = lowest value first, dsc = highest first
+//    ping: 1                                         // ping first, default true
 //  }
 // TODO: add caching with configurable time limit for results
 // This will ALWAYS ping first with getNodesBy.ping()
@@ -322,7 +357,18 @@ exports.rawmempool = (options) => {
   pingOptions.order = 'asc'
 
   return new Promise((resolve, reject) => {
-    this.ping(pingOptions).then(nodes => {
+    if (parseInt(options.ping)) {
+      this.ping(pingOptions).then(nodes => {
+        rawmempoolCallback(nodes)
+      })
+      .catch (error => {
+        print(__filename + ': getNodesBy.rawmempool()/getNodesBy.ping().error: ' + error)
+      })
+    } else {
+      rawmempoolCallback(options.nodes)
+    }
+
+    function rawmempoolCallback(nodes) {
       if (_.isArray(nodes)) {
         nodes.forEach((n) => {
           if (n.url) {
@@ -349,10 +395,7 @@ exports.rawmempool = (options) => {
           }
         })
       }
-    })
-    .catch (error => {
-      print(__filename + ': getNodesBy.rawmempool()/getNodesBy.ping().error: ' + error)
-    })
+    }
   })
 }
 


### PR DESCRIPTION
Now, all methods except "all" can have ping first behavior toggled with -p --ping